### PR TITLE
ci: update build action

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -78,6 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v3
+      - name: Deploy GitHub Pages site
+        uses: actions/deploy-pages@v4.0.5
+        with:
+          # GitHub token
+          token: ${{ github.token }}
+          


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to GitHub Pages. The change involves upgrading the deployment action to a newer version and adding configuration for the GitHub token.

Workflow updates:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL81-R86): Updated the `actions/deploy-pages` action from version `v3` to `v4.0.5` and added a `with` block to configure the `token` parameter using `${{ github.token }}`.