### PR TITLE
feat: stop metronome on timer end

### DIFF
--- a/src/components/metronome/MetronomeContainer.tsx
+++ b/src/components/metronome/MetronomeContainer.tsx
@@ -29,9 +29,24 @@ const MetronomeContainer = ({
     isPlaying,
   });
 
+  // Handle timer end by stopping the metronome
+  const handleTimerEnd = () => {
+    console.log("Timer ended, stopping metronome. isPlaying:", isPlaying);
+    
+    // Directly stop the metronome through the hook
+    setIsPlaying(false);
+    
+    // Also update the parent component state
+    if (isPlaying) {
+      console.log("Calling onPlayToggle to update parent state");
+      onPlayToggle(); // This will toggle isPlaying to false in the parent component
+    }
+  };
+
   const { time, resetTimer, setInitialTime } = useTimer({
     isRunning: isPlaying && isTimerEnabled,
     initialTime: 300000, // 5 minutes default
+    onTimerEnd: handleTimerEnd, // Pass the callback to stop when timer ends
   });
 
   useEffect(() => {

--- a/src/tests/components/MetronomeContainer.test.tsx
+++ b/src/tests/components/MetronomeContainer.test.tsx
@@ -1,0 +1,101 @@
+import MetronomeContainer from '@/components/metronome/MetronomeContainer';
+import { useMetronome } from '@/hooks/useMetronome';
+import { useTimer } from '@/hooks/useTimer';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the hooks
+vi.mock('@/hooks/useTimer', () => ({
+  useTimer: vi.fn(),
+}));
+
+vi.mock('@/hooks/useMetronome', () => ({
+  useMetronome: vi.fn(),
+}));
+
+describe('MetronomeContainer', () => {
+  const resetTimerMock = vi.fn();
+  const setInitialTimeMock = vi.fn();
+  const setIsPlayingMock = vi.fn();
+  const onPlayToggleMock = vi.fn();
+  const onTimerToggleMock = vi.fn();
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default mock implementations
+    (useTimer as any).mockReturnValue({
+      time: 300000, // 5 minutes
+      resetTimer: resetTimerMock,
+      setInitialTime: setInitialTimeMock
+    });
+    
+    (useMetronome as any).mockReturnValue({
+      currentBeat: 1,
+      setIsPlaying: setIsPlayingMock
+    });
+  });
+
+  it('should stop the metronome when timer ends', () => {
+    // Define what will happen when useTimer is called
+    let timerEndCallback: (() => void) | undefined;
+    
+    (useTimer as any).mockImplementation(({ onTimerEnd }: { onTimerEnd?: () => void }) => {
+      // Save the callback for later use
+      timerEndCallback = onTimerEnd;
+      
+      return {
+        time: 0, // Timer at zero
+        resetTimer: resetTimerMock,
+        setInitialTime: setInitialTimeMock,
+      };
+    });
+    
+    render(
+      <MetronomeContainer
+        isTimerEnabled={true}
+        isPlaying={true}
+        onTimerToggle={onTimerToggleMock}
+        onPlayToggle={onPlayToggleMock}
+      />
+    );
+    
+    // Trigger the timer end callback
+    act(() => {
+      if (timerEndCallback) {
+        timerEndCallback();
+      }
+    });
+    
+    // Verify that onPlayToggle was called to stop the metronome
+    expect(onPlayToggleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render timer display when timer is enabled', () => {
+    render(
+      <MetronomeContainer
+        isTimerEnabled={true}
+        isPlaying={false}
+        onTimerToggle={onTimerToggleMock}
+        onPlayToggle={onPlayToggleMock}
+      />
+    );
+    
+    // Check for the reset timer button which is part of the timer display
+    expect(screen.getByTitle('Reset Timer')).toBeInTheDocument();
+  });
+
+  it('should not render timer display when timer is disabled', () => {
+    render(
+      <MetronomeContainer
+        isTimerEnabled={false}
+        isPlaying={false}
+        onTimerToggle={onTimerToggleMock}
+        onPlayToggle={onPlayToggleMock}
+      />
+    );
+    
+    // Timer display should not be present
+    expect(screen.queryByTitle('Reset Timer')).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/hooks/useTimer.test.ts
+++ b/src/tests/hooks/useTimer.test.ts
@@ -10,7 +10,7 @@ describe('useTimer', () => {
     vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
     
     // Helper to advance the mock time
-    global.advanceTime = (ms: number) => {
+    (global as any).advanceTime = (ms: number) => {
       currentTime += ms;
       vi.advanceTimersByTime(ms);
     };
@@ -83,5 +83,36 @@ describe('useTimer', () => {
     
     // Time should still be 1000 as the timer is paused
     expect(result.current.time).toBe(1000);
+  });
+  
+  it('should call onTimerEnd when timer reaches zero', () => {
+    const onTimerEnd = vi.fn();
+    const { result } = renderHook(() => 
+      useTimer({ 
+        isRunning: true, 
+        initialTime: 2000, 
+        onTimerEnd 
+      })
+    );
+    
+    // First tick
+    act(() => {
+      (global as any).advanceTime(1000);
+    });
+    expect(result.current.time).toBe(1000);
+    expect(onTimerEnd).not.toHaveBeenCalled();
+    
+    // Second tick reaches zero
+    act(() => {
+      (global as any).advanceTime(1000);
+    });
+    expect(result.current.time).toBe(0);
+    expect(onTimerEnd).toHaveBeenCalledTimes(1);
+    
+    // No more calls after reaching zero
+    act(() => {
+      (global as any).advanceTime(1000);
+    });
+    expect(onTimerEnd).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This pull request introduces enhancements to the metronome functionality by integrating a timer callback mechanism and adding corresponding unit tests. The key changes include the addition of an `onTimerEnd` callback in the `useTimer` hook, updates to the `MetronomeContainer` component to handle timer end events, and comprehensive test cases to verify the new behavior.

### Enhancements to Timer Functionality:

* **Added `onTimerEnd` callback to `useTimer` hook**: The `useTimer` hook now accepts an optional `onTimerEnd` callback, which is invoked when the timer reaches zero. This ensures other components can respond to the timer's completion. (`src/hooks/useTimer.ts`, [[1]](diffhunk://#diff-a204051131c6e615e55bb58909af83ed6247abd2336bcea482c3c05a2fe586eeR6-R19) [[2]](diffhunk://#diff-a204051131c6e615e55bb58909af83ed6247abd2336bcea482c3c05a2fe586eeR29-R73)

* **Updated `MetronomeContainer` to handle timer end**: Introduced a `handleTimerEnd` function in `MetronomeContainer` to stop the metronome and update the parent component's state when the timer ends. The `onTimerEnd` callback is passed from the `useTimer` hook. (`src/components/metronome/MetronomeContainer.tsx`, [src/components/metronome/MetronomeContainer.tsxR32-R49](diffhunk://#diff-d8ba9461eace44ab534bbaece9eef65c772bf2231f686dfb21dcbb55f968ab5dR32-R49))

### Unit Tests:

* **New tests for `MetronomeContainer`**: Added tests to verify the behavior of the `MetronomeContainer` when the timer ends, ensuring the metronome stops and the parent state is updated. Also included tests for rendering the timer display based on its enabled/disabled state. (`src/tests/components/MetronomeContainer.test.tsx`, [src/tests/components/MetronomeContainer.test.tsxR1-R101](diffhunk://#diff-a7be3bd0f12434fc7c17b97996ae05f6ed85f90dea729ddfc1b225bd50a3cb6dR1-R101))

* **Enhanced `useTimer` tests**: Added a test case to confirm the `onTimerEnd` callback is called exactly once when the timer reaches zero, and not afterward. (`src/tests/hooks/useTimer.test.ts`, [src/tests/hooks/useTimer.test.tsR87-R117](diffhunk://#diff-6ce86a46bb2e4cb1b112011de12dec0addff084a7afd722d9a3620d25d741fe2R87-R117))

### Miscellaneous:

* **Fixed global time advancement in tests**: Updated the `advanceTime` helper in `useTimer` tests to use a type-safe cast for `global`. (`src/tests/hooks/useTimer.test.ts`, [src/tests/hooks/useTimer.test.tsL13-R13](diffhunk://#diff-6ce86a46bb2e4cb1b112011de12dec0addff084a7afd722d9a3620d25d741fe2L13-R13))